### PR TITLE
[UI][Louise] adjusted event image component for unrevealed events

### DIFF
--- a/components/home/EventImage.tsx
+++ b/components/home/EventImage.tsx
@@ -4,27 +4,36 @@ import Image from 'next/image';
 
 interface IProps {
     imageUrl: string;
+    blackImageURL: string;
     name: string;
     eventURL: string;
+    isRevealed: boolean;
 }
 
 const EventImage = (props: IProps) => {
-    const { imageUrl, name, eventURL } = props;
+    const { imageUrl, blackImageURL, name, eventURL, isRevealed } = props;
 
     const imageContent = (
         <figure className="relative aspect-square w-28 sm:w-52 md:w-52 lg:w-64 xl:w-96 hover:scale-105 duration-200">
-            <Image src={imageUrl} alt="guest" fill className="object-cover" />
+            <Image
+                src={isRevealed ? imageUrl : blackImageURL}
+                alt="guest"
+                fill
+                className="object-cover"
+            />
         </figure>
     );
 
     return (
         <div className="flex flex-col items-center text-center text-md md:text-xl gap-2">
-            {eventURL ? (
+            {isRevealed ? (
                 <Link href={eventURL}>{imageContent}</Link>
             ) : (
                 imageContent
             )}
-            <p className="text-xs md:text-sm lg:text-md xl:text-lg">{name}</p>
+            <p className="text-xs md:text-sm lg:text-md xl:text-lg">
+                {isRevealed ? name : '??? Competition'}
+            </p>
         </div>
     );
 };

--- a/components/home/EventSection.tsx
+++ b/components/home/EventSection.tsx
@@ -29,8 +29,10 @@ const EventSection = () => {
                     <EventImage
                         key={index + currentEvent.eventName}
                         imageUrl={currentEvent.imageUrl}
+                        blackImageURL={currentEvent.blackImageUrl}
                         name={currentEvent.eventName}
                         eventURL={currentEvent.eventURL}
+                        isRevealed={currentEvent.isRevealed}
                     />
                 ))}
             </div>
@@ -45,8 +47,10 @@ const EventSection = () => {
                     <EventImage
                         key={index + currentEvent.eventName}
                         imageUrl={currentEvent.imageUrl}
+                        blackImageURL={currentEvent.blackImageUrl}
                         name={currentEvent.eventName}
                         eventURL={currentEvent.eventURL}
+                        isRevealed={currentEvent.isRevealed}
                     />
                 ))}
             </div>

--- a/enums/imageUrls.ts
+++ b/enums/imageUrls.ts
@@ -37,64 +37,91 @@ export const EVENTS = {
     SOLO_SKIT: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515389/solo_coskit_m0l3yt.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515389/solo_coskit_m0l3yt.png',
         eventName: 'Solo Skit Cosplay Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSfxnUShZ0f5hYKj_UySg5BiUzK3kIuzoqLL2qQRDE2YYw5Rzg',
+        isRevealed: true,
     },
     DUO_SKIT: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/duo_coskit_qtbaxi.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/duo_coskit_qtbaxi.png',
         eventName: 'Duo Skit Cosplay Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSezmXO3epsnxFuXApPv4j6X9651vXdj2TUhe85qSLh6YuS7ZQ',
+        isRevealed: true,
     },
     SOLO_DUO_ASIAN_GROOVE: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515392/ags_solo_duo_xbzyna.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515392/ags_solo_duo_xbzyna.png',
         eventName: 'Solo/Duo Asian Groove Showdown',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLScRtqkniAmwwwyQmUTek0JAutUnjaHw4fjd76jlO6RE8MfMWg',
+        isRevealed: true,
     },
     GROUP_ASIAN_GROOVE: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515392/ags_group_qsovxw.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515392/ags_group_qsovxw.png',
         eventName: 'Group Asian Groove Showdown',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSdVmtu72WBmpKTrxiTyEA_lDVjN2ECZcmt-T3slXLb2SCUnvg',
+        isRevealed: true,
     },
     KARAOKE_JAPANESE_SINGING: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/japsing_nwqgsb.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/japsing_nwqgsb.png',
         eventName: 'Kara-OK!! Japanese Singing Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSee3wJ4dZ9o9tTLfKI53Nbp_UZOJhFsk_YKxNzt1R1nuU0JBw',
+        isRevealed: true,
     },
     ORIGINAL_CHARACTER_DESIGN: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/ocd_llmgxw.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/ocd_llmgxw.png',
         eventName: 'Original Character Design Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSfg0XgQI7YBhlXUIbS8Dnr5mdvs2VwzEKL4vFDDwte2wp1-aw',
+        isRevealed: true,
     },
     ONE_SHOT_COMIC: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/osc_xdnzab.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/osc_xdnzab.png',
         eventName: 'One-Shot Comic Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSehcJNy5v4OWG3qTQkD4_Pb3OD-YFIXWljNl4QiqykiOKTzWw',
+        isRevealed: true,
     },
     ANIMATION: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/animotion_gif_rg0uj7.gif',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/animotion_gif_rg0uj7.gif',
         eventName: 'AniMotion! Animation Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSdNaXgg4BfZUlGGhfgINULA-32nWwgbcfJ6aZ7LNsDCkNKLWg',
+        isRevealed: true,
     },
     COMING_SOON: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/coming_soon_por0sv.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/coming_soon_por0sv.png',
         eventName: '??? Competition',
         eventURL: '',
+        isRevealed: false,
     },
 };
 
@@ -102,48 +129,58 @@ export const PARTNERED_EVENTS = {
     SABERSTURM: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/sabersturm_szozxk.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/sabersturm_szozxk.png',
         eventName: 'Sabersturm Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLScHr-cSn6CxjbIOJuJHU8RyULnOeB597Zk7zRfU5za_WwFfCQ',
+        isRevealed: true,
     },
     GUNPLA: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/gunpla_inzsrh.png',
         blackImageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/gunpla_blk_zqww85.png',
-        eventName: '??? Competition',
+        eventName: 'Gundam Plastic Competition',
         eventURL:
             'https://formfacade.com/public/112519215755839682426/all/form/1FAIpQLSfpOaoZtw7tpWTR0GIYmbnbdN9NBIUdy8bnPiz5D9i-kY_ZQg',
+        isRevealed: true,
     },
     YUGIOH: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515389/ygo_rtczy8.png',
         blackImageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515388/ygo_blk_xxxs80.png',
-        eventName: '??? Competition',
+        eventName: 'Yu-Gi-Oh! Competition',
         eventURL: '',
+        isRevealed: false,
     },
     VANGUARD: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/cfv_vvdnnu.png',
         blackImageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/cfv_blk_wimd03.png',
-        eventName: '??? Competition',
+        eventName: 'Vanguard Competition',
         eventURL: '',
+        isRevealed: false,
     },
     DND: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515392/dnd_fvwhpn.png',
         blackImageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515390/dnd_blk_b8zvvt.png',
-        eventName: '??? Competition',
+        eventName: 'Dungeon & Dragons Competition',
         eventURL: '',
+        isRevealed: false,
     },
     COMING_SOON: {
         imageUrl:
             'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/coming_soon_por0sv.png',
+        blackImageUrl:
+            'https://res.cloudinary.com/dhyoibvtc/image/upload/v1718515391/coming_soon_por0sv.png',
         eventName: '??? Competition',
         eventURL: '',
+        isRevealed: false,
     },
 };
 


### PR DESCRIPTION
@maxellmilay @arwin50 unrevealed/blackened events do not redirect anywhere if clicked

[image](https://github.com/maxellmilay/otakufest-ph/assets/119489421/39f66c8e-f8fd-4d3c-911a-2f34a2db33a1)
![image](https://github.com/maxellmilay/otakufest-ph/assets/119489421/59789fd3-20fd-4168-839b-571984817840)
*pictures attached only to show functionality, events in PR already set correctly if currently revealed or unrevealed